### PR TITLE
Feat/#47 Pressed Button만을 위한 Color Design Token을 추가하고, 해당 토큰을 SPButton에 적용하였습니다.

### DIFF
--- a/SplitIt/Resources/Components/SPButton.swift
+++ b/SplitIt/Resources/Components/SPButton.swift
@@ -20,7 +20,6 @@ extension SPButton {
         case primaryPear
         case primaryMushroom
         case primaryRadish
-        case secondary
         case warningRed
         
         // MARK: Pressed Normal Button Styles
@@ -30,12 +29,17 @@ extension SPButton {
         case primaryPearPressed
         case primaryMushroomPressed
         case primaryRadishPressed
-        case secondaryPressed
         case warningRedPressed
         
         // MARK: Active Square Button Styles
         case squarePrimaryCalmshell
+        case squarePrimaryWatermelon
         case squareWarningRed
+        
+        // MARK: Pressed Square Button Styles
+        case squarePrimaryCalmshellPressed
+        case squarePrimaryWatermelonPressed
+        case squareWarningRedPressed
         
         // MARK: Active Half Button Styles
         case halfSmartSplit
@@ -79,6 +83,7 @@ final class SPButton: UIButton {
         setCurrencyLabel(style: style)
         
         switch style {
+            
         // 활성 버튼, Unpressed 상태
         case .primaryCalmshell:
             self.backgroundColor = .SurfaceBrandCalmshell
@@ -115,64 +120,52 @@ final class SPButton: UIButton {
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configureUnpressedProperties()
-        
-        case .secondary:
-            self.backgroundColor = .SurfaceDeactivate
-            self.configureCommonPropertiesForNormal()
-            self.configureActiveProperties()
-            self.configureUnpressedProperties()
             
         case .warningRed:
-            self.backgroundColor = .SurfaceWarn
+            self.backgroundColor = .SurfaceWarnRed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configureUnpressedProperties()
         
         // 비활성 버튼, Pressed 상태
         case .primaryCalmshellPressed:
-            self.backgroundColor = .SurfaceBrandCalmshell
+            self.backgroundColor = .SurfaceBrandCalmshellPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
         
         case .primaryWatermelonPressed:
-            self.backgroundColor = .SurfaceBrandWatermelon
+            self.backgroundColor = .SurfaceBrandWatermelonPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
 
         case .primaryCherryPressed:
-            self.backgroundColor = .SurfaceBrandCherry
+            self.backgroundColor = .SurfaceBrandCherryPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
 
         case .primaryPearPressed:
-            self.backgroundColor = .SurfaceBrandPear
+            self.backgroundColor = .SurfaceBrandPearPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
 
         case .primaryMushroomPressed:
-            self.backgroundColor = .SurfaceBrandMushroom
+            self.backgroundColor = .SurfaceBrandMushroomPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
         
         case .primaryRadishPressed:
-            self.backgroundColor = .SurfaceBrandRadish
-            self.configureCommonPropertiesForNormal()
-            self.configureActiveProperties()
-            self.configurePressedProperties()
-
-        case .secondaryPressed:
-            self.backgroundColor = .SurfaceDeactivate
+            self.backgroundColor = .SurfaceBrandRadishPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
 
         case .warningRedPressed:
-            self.backgroundColor = .SurfaceWarn
+            self.backgroundColor = .SurfaceWarnRedPressed
             self.configureCommonPropertiesForNormal()
             self.configureActiveProperties()
             self.configurePressedProperties()
@@ -182,13 +175,38 @@ final class SPButton: UIButton {
             self.backgroundColor = .SurfaceBrandCalmshell
             self.configureCommonPropertiesForSquare()
             self.configureActiveProperties()
-            self.configureUnpressedProperties()
+            self.configureUnpressedPropertiesForSquare()
             
-        case .squareWarningRed:
-            self.backgroundColor = .SurfaceWarn
+        case .squarePrimaryWatermelon:
+            self.backgroundColor = .SurfaceBrandWatermelon
             self.configureCommonPropertiesForSquare()
             self.configureActiveProperties()
-            self.configureUnpressedProperties()
+            self.configureUnpressedPropertiesForSquare()
+            
+        case .squareWarningRed:
+            self.backgroundColor = .SurfaceWarnRed
+            self.configureCommonPropertiesForSquare()
+            self.configureActiveProperties()
+            self.configureUnpressedPropertiesForSquare()
+            
+        // 비활성, 사각 버튼 Pressed 상태
+        case .squarePrimaryCalmshellPressed:
+            self.backgroundColor = .SurfaceBrandCalmshellPressed
+            self.configureCommonPropertiesForSquare()
+            self.configureActiveProperties()
+            self.configurePressedPropertiesForSquare()
+            
+        case .squarePrimaryWatermelonPressed:
+            self.backgroundColor = .SurfaceBrandWatermelonPressed
+            self.configureCommonPropertiesForSquare()
+            self.configureActiveProperties()
+            self.configurePressedPropertiesForSquare()
+            
+        case .squareWarningRedPressed:
+            self.backgroundColor = .SurfaceWarnRedPressed
+            self.configureCommonPropertiesForSquare()
+            self.configureActiveProperties()
+            self.configurePressedPropertiesForSquare()
             
         // 활성 하프 버튼
         case .halfSmartSplit:
@@ -217,19 +235,19 @@ final class SPButton: UIButton {
             
         // 비활성, 하프 버튼 Pressed 상태
         case .halfSmartSplitPressed:
-            self.backgroundColor = .SurfaceBrandCalmshell
+            self.backgroundColor = .SurfaceBrandCalmshellPressed
             self.configureCommonPropertiesForHalf()
             self.configureActiveProperties()
             self.configurePressedProperties()
             
         case .halfEqualSplitPressed:
-            self.backgroundColor = .SurfaceBrandCalmshell
+            self.backgroundColor = .SurfaceBrandCalmshellPressed
             self.configureCommonPropertiesForHalf()
             self.configureActiveProperties()
             self.configurePressedProperties()
         
         case .halfSharePressed:
-            self.backgroundColor = .SurfaceBrandCalmshell
+            self.backgroundColor = .SurfaceBrandCalmshellPressed
             self.configureCommonPropertiesForHalf()
             self.configureActiveProperties()
             self.configurePressedProperties()
@@ -251,7 +269,7 @@ final class SPButton: UIButton {
             self.backgroundColor = .SurfaceBrandCalmshell
             self.configureCommonPropertiesForSquare()
             self.configureDeactiveProperties()
-            self.configurePressedProperties()
+            self.configurePressedPropertiesForSquare()
             
         case .halfSmartSplitDeactivate:
             self.backgroundColor = .SurfaceBrandCalmshell
@@ -318,15 +336,26 @@ final class SPButton: UIButton {
         self.layer.shadowColor = UIColor.BorderDeactivate.cgColor
     }
     
-    // 사용자가 탭하기 전 프로퍼티
+    // 일반 버튼, 사용자가 탭하기 전 프로퍼티
     private func configureUnpressedProperties() {
         self.layer.shadowOffset = CGSize(width: 0, height: 8)
     }
     
-    // 사용자가 탭한 뒤 프로퍼티
+    // 일반 버튼, 사용자가 탭한 뒤 프로퍼티
     private func configurePressedProperties() {
         self.isEnabled = false
         self.layer.shadowOffset = CGSize(width: 0, height: 3)
+    }
+    
+    // 사각 버튼, 사용자가 탭하기 전 프로퍼티
+    private func configureUnpressedPropertiesForSquare() {
+        self.layer.shadowOffset = CGSize(width: 0, height: 3)
+    }
+    
+    // 사각 버튼, 사용자가 탭한 뒤 프로퍼티
+    private func configurePressedPropertiesForSquare() {
+        self.isEnabled = false
+        self.layer.shadowOffset = CGSize(width: 0, height: 1)
     }
     
     private func setCurrencyIcon(style: SPButton.Style) {
@@ -351,8 +380,6 @@ final class SPButton: UIButton {
             break
         case .primaryRadish:
             break
-        case .secondary:
-            break
         case .warningRed:
             break
         case .primaryCalmshellPressed:
@@ -367,17 +394,23 @@ final class SPButton: UIButton {
             break
         case .primaryRadishPressed:
             break
-        case .secondaryPressed:
-            break
         case .warningRedPressed:
             break
         case .squarePrimaryCalmshell:
+            break
+        case .squarePrimaryWatermelon:
             break
         case .squareWarningRed:
             break
         case .deactivate:
             break
         case .squareDeactivate:
+            break
+        case .squarePrimaryCalmshellPressed:
+            break
+        case .squarePrimaryWatermelonPressed:
+            break
+        case .squareWarningRedPressed:
             break
         case .halfSmartSplit:
             currencyIcon.image = UIImage(named:"SplitIconDefault")
@@ -427,8 +460,6 @@ final class SPButton: UIButton {
             break
         case .primaryRadish:
             break
-        case .secondary:
-            break
         case .warningRed:
             break
         case .primaryCalmshellPressed:
@@ -443,13 +474,19 @@ final class SPButton: UIButton {
             break
         case .primaryRadishPressed:
             break
-        case .secondaryPressed:
-            break
         case .warningRedPressed:
             break
         case .squarePrimaryCalmshell:
             break
+        case .squarePrimaryWatermelon:
+            break
         case .squareWarningRed:
+            break
+        case .squarePrimaryCalmshellPressed:
+            break
+        case .squarePrimaryWatermelonPressed:
+            break
+        case .squareWarningRedPressed:
             break
         case .deactivate:
             break

--- a/SplitIt/Resources/Extensions/UIColor+.swift
+++ b/SplitIt/Resources/Extensions/UIColor+.swift
@@ -178,11 +178,19 @@ extension UIColor {
     class var SurfaceWhite: UIColor { return UIColor.AppColorGrayscaleBase }
 
     /**
+     주의 및 경고의 색상이 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-warn
+     */
+    class var SurfaceWarnRed: UIColor { return UIColor.AppColorStatusWarnRedPressed }
+    
+    /**
      주의 및 경고의 면의 색상입니다.
      - parameters:
         - property: $surface-warn
      */
-    class var SurfaceWarn: UIColor { return UIColor.AppColorStatusWarnRed }
+    class var SurfaceWarnRedPressed: UIColor { return UIColor.AppColorStatusWarnRed }
+
 
 
     // MARK: Border Colors
@@ -238,7 +246,7 @@ extension UIColor {
     class var AppColorBrandPearPressed: UIColor { return UIColor(hex: 0xAFD73D) }
     class var AppColorBrandMushroomPressed: UIColor { return UIColor(hex: 0xF3C245) }
     class var AppColorBrandRadishPressed: UIColor { return UIColor(hex: 0xFFB598) }
-    class var AppColorWarnRedPressed: UIColor { return UIColor(hex: 0xD84961) }
+    class var AppColorStatusWarnRedPressed: UIColor { return UIColor(hex: 0xD84961) }
 
     // MARK: Grayscale Colors
     class var AppColorGrayscaleBase: UIColor { return UIColor(hex: 0xFFFFFF) }

--- a/SplitIt/Resources/Extensions/UIColor+.swift
+++ b/SplitIt/Resources/Extensions/UIColor+.swift
@@ -93,12 +93,26 @@ extension UIColor {
      */
     class var SurfaceBrandCalmshell: UIColor { return UIColor.AppColorBrandCalmshell }
     
+    
+     /** 브랜드 색상 'Calmshell'이 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-brand-calmshell
+     */
+    class var SurfaceBrandCalmshellPressed: UIColor { return UIColor.AppColorBrandCalmshellPressed }
+    
     /**
      브랜드 색상 'Watermelon'이 적용되는 면의 색상입니다.
      - parameters:
         - property: $surface-brand-watermelon
      */
     class var SurfaceBrandWatermelon: UIColor { return UIColor.AppColorBrandWatermelon }
+    
+    /**
+     브랜드 색상 'Watermelon'이 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-brand-watermelon
+     */
+    class var SurfaceBrandWatermelonPressed: UIColor { return UIColor.AppColorBrandWatermelonPressed }
     
     /**
      브랜드 색상 'Cherry'가 적용되는 면의 색상입니다.
@@ -108,11 +122,25 @@ extension UIColor {
     class var SurfaceBrandCherry: UIColor { return UIColor.AppColorBrandCherry }
     
     /**
+     브랜드 색상 'Cherry'가 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-brand-cherry
+     */
+    class var SurfaceBrandCherryPressed: UIColor { return UIColor.AppColorBrandCherryPressed }
+    
+    /**
      브랜드 색상 'Pear'가 적용되는 면의 색상입니다.
      - parameters:
         - property: $surface-brand-pear
      */
     class var SurfaceBrandPear: UIColor { return UIColor.AppColorBrandPear }
+    
+    /**
+     브랜드 색상 'Pear'가 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-brand-pear
+     */
+    class var SurfaceBrandPearPressed: UIColor { return UIColor.AppColorBrandPearPressed }
     
     /**
      브랜드 색상 'Mushroom'이 적용되는 면의 색상입니다.
@@ -122,11 +150,25 @@ extension UIColor {
     class var SurfaceBrandMushroom: UIColor { return UIColor.AppColorBrandMushroom }
     
     /**
+     브랜드 색상 'Mushroom'이 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-brand-mushroom
+     */
+    class var SurfaceBrandMushroomPressed: UIColor { return UIColor.AppColorBrandMushroomPressed }
+    
+    /**
      브랜드 색상 'Radish'가 적용되는 면의 색상입니다.
      - parameters:
         - property: $surface-brand-radish
      */
     class var SurfaceBrandRadish: UIColor { return UIColor.AppColorBrandRadish }
+    
+    /**
+     브랜드 색상 'Radish'가 적용되는 Button의 Pressed 상태를 위한 색상입니다.
+     - parameters:
+        - property: $surface-brand-radish
+     */
+    class var SurfaceBrandRadishPressed: UIColor { return UIColor.AppColorBrandRadishPressed }
 
     /**
      흰색의 면의 색상입니다.
@@ -188,6 +230,15 @@ extension UIColor {
     class var AppColorBrandPear: UIColor { return UIColor(hex: 0xDEF358) }
     class var AppColorBrandMushroom: UIColor { return UIColor(hex: 0xF1D367) }
     class var AppColorBrandRadish: UIColor { return UIColor(hex: 0xFFCBB7) }
+    
+    // MARK: Pressed Colors
+    class var AppColorBrandCalmshellPressed: UIColor { return UIColor(hex: 0xEEEDE8) }
+    class var AppColorBrandWatermelonPressed: UIColor { return UIColor(hex: 0x3C9293) }
+    class var AppColorBrandCherryPressed: UIColor { return UIColor(hex: 0xEE778D) }
+    class var AppColorBrandPearPressed: UIColor { return UIColor(hex: 0xAFD73D) }
+    class var AppColorBrandMushroomPressed: UIColor { return UIColor(hex: 0xF3C245) }
+    class var AppColorBrandRadishPressed: UIColor { return UIColor(hex: 0xFFB598) }
+    class var AppColorWarnRedPressed: UIColor { return UIColor(hex: 0xD84961) }
 
     // MARK: Grayscale Colors
     class var AppColorGrayscaleBase: UIColor { return UIColor(hex: 0xFFFFFF) }


### PR DESCRIPTION
### 작업 내용 설명
1. `UIColor+.swift`에 Pressed의 상태의 Button을 위한 Color Design Token을 추가하였습니다.
2. 'SPButton.swift'에 해당 컬러를 적용한 case들을 추가하였습니다.
3. 코리와 디자인 상의 후, 사각버튼의 눌림 효과를 추가하였습니다.

### 관련 이슈
- #47 

### 작업의 결과물
``` Swift
...
    
     /** 브랜드 색상 'Calmshell'이 적용되는 Button의 Pressed 상태를 위한 색상입니다.
     - parameters:
        - property: $surface-brand-calmshell
     */
    class var SurfaceBrandCalmshellPressed: UIColor { return UIColor.AppColorBrandCalmshellPressed }
    
    // 같은 방식으로 반복
...
```

``` Swift
...

        // 비활성, 사각 버튼 Pressed 상태
        case .squarePrimaryCalmshellPressed:
            self.backgroundColor = .SurfaceBrandCalmshellPressed
            self.configureCommonPropertiesForSquare()
            self.configureActiveProperties()
            self.configurePressedPropertiesForSquare()
            
        case .squarePrimaryWatermelonPressed:
            self.backgroundColor = .SurfaceBrandWatermelonPressed
            self.configureCommonPropertiesForSquare()
            self.configureActiveProperties()
            self.configurePressedPropertiesForSquare()
            
        case .squareWarningRedPressed:
            self.backgroundColor = .SurfaceWarnRedPressed
            self.configureCommonPropertiesForSquare()
            self.configureActiveProperties()
            self.configurePressedPropertiesForSquare()

...
```

Close #47 
