### PR TITLE
[Feat/#116] SPbutton.swift를 복제한 NewSPButton.swift을 생성하여 리팩토링하였습니다.

### DIFF
--- a/SplitIt.xcodeproj/project.pbxproj
+++ b/SplitIt.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		869D1AF22AE52C9B00D166B1 /* ExclMemberEditSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869D1AF12AE52C9B00D166B1 /* ExclMemberEditSectionModel.swift */; };
 		869D1AF42AE52CAC00D166B1 /* ExclMemberEditSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869D1AF32AE52CAC00D166B1 /* ExclMemberEditSectionHeader.swift */; };
 		86D1E0C52AE6B4C100FBF610 /* ExclEditPageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D1E0C42AE6B4C100FBF610 /* ExclEditPageController.swift */; };
+		C229F51A2AEA442E00F9E28D /* NewSPButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C229F5192AEA442E00F9E28D /* NewSPButton.swift */; };
 		C2A7978D2AE2740D0049E709 /* ONEMobileBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A7978A2AE2740D0049E709 /* ONEMobileBold.ttf */; };
 		C2A7978E2AE2740D0049E709 /* ONEMobileLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A7978B2AE2740D0049E709 /* ONEMobileLight.ttf */; };
 		C2A7978F2AE2740D0049E709 /* ONEMobileRegular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A7978C2AE2740D0049E709 /* ONEMobileRegular.ttf */; };
@@ -241,6 +242,7 @@
 		869D1AF12AE52C9B00D166B1 /* ExclMemberEditSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclMemberEditSectionModel.swift; sourceTree = "<group>"; };
 		869D1AF32AE52CAC00D166B1 /* ExclMemberEditSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclMemberEditSectionHeader.swift; sourceTree = "<group>"; };
 		86D1E0C42AE6B4C100FBF610 /* ExclEditPageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclEditPageController.swift; sourceTree = "<group>"; };
+		C229F5192AEA442E00F9E28D /* NewSPButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSPButton.swift; sourceTree = "<group>"; };
 		C2A7978A2AE2740D0049E709 /* ONEMobileBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ONEMobileBold.ttf; sourceTree = "<group>"; };
 		C2A7978B2AE2740D0049E709 /* ONEMobileLight.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ONEMobileLight.ttf; sourceTree = "<group>"; };
 		C2A7978C2AE2740D0049E709 /* ONEMobileRegular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ONEMobileRegular.ttf; sourceTree = "<group>"; };
@@ -852,6 +854,7 @@
 				C2A797932AE274F10049E709 /* SPTextField.swift */,
 				C2A797952AE275110049E709 /* SPButton.swift */,
 				1AF9F0962AE2A10D000F580B /* NavigationBar.swift */,
+				C229F5192AEA442E00F9E28D /* NewSPButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1144,6 +1147,7 @@
 				869D1ADC2AE52B8800D166B1 /* CSMemberEditCell.swift in Sources */,
 				C2A797A42AE278190049E709 /* HistoryVC.swift in Sources */,
 				60115E162ADCDB840050D32C /* CSTotalAmountInputVM.swift in Sources */,
+				C229F51A2AEA442E00F9E28D /* NewSPButton.swift in Sources */,
 				C2A797912AE2748E0049E709 /* UIFont+.swift in Sources */,
 				60115E312ADE715E0050D32C /* CSMemberConfirmHeaderVM.swift in Sources */,
 				6009C8162AE29DFB008B9EC1 /* ResultVM.swift in Sources */,

--- a/SplitIt/Resources/Components/NewSPButton.swift
+++ b/SplitIt/Resources/Components/NewSPButton.swift
@@ -1,0 +1,411 @@
+//
+//  NewSPButton.swift
+//  SplitIt
+//
+//  Created by SUNGIL-POS on 2023/10/26.
+//
+
+import UIKit
+import SnapKit
+import RxCocoa
+import RxSwift
+
+//MARK: 토마토 Task
+final class NewSPButton: UIButton {
+    let buttonState = BehaviorRelay<Bool>(value: false)
+    let currencyIcon = UIImageView()
+    let currencyLabel = UILabel()
+
+    let colorArray: [Style: UIColor] = [
+            .primaryCalmshell: .SurfaceBrandCalmshell,
+            .primaryWatermelon: .SurfaceBrandWatermelon,
+            .primaryCherry: .SurfaceBrandCherry,
+            .primaryPear: .SurfaceBrandPear,
+            .primaryMushroom: .SurfaceBrandMushroom,
+            .primaryRadish: .SurfaceBrandRadish,
+            .warningRed: .SurfaceWarnRed,
+            .halfSmartSplit: .SurfaceBrandCalmshell,
+            .halfEqualSplit: .SurfaceBrandCalmshell,
+    ]
+
+    let colorPressedArray: [Style: UIColor] = [
+            .primaryCalmshell: .SurfaceBrandCalmshellPressed,
+            .primaryWatermelon: .SurfaceBrandWatermelonPressed,
+            .primaryCherry: .SurfaceBrandCherryPressed,
+            .primaryPear: .SurfaceBrandPearPressed,
+            .primaryMushroom: .SurfaceBrandMushroomPressed,
+            .primaryRadish: .SurfaceBrandRadishPressed,
+            .warningRed: .SurfaceWarnRedPressed,
+            .halfSmartSplit: .SurfaceBrandCalmshellPressed,
+            .halfEqualSplit: .SurfaceBrandCalmshellPressed,
+    ]
+
+    var disposeBag = DisposeBag()
+
+    // MARK: - Initializer
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Style Configuration
+    
+    // 공통 프로퍼티
+    private func configureCommonProperties() {
+        self.layer.masksToBounds = false
+        self.layer.borderWidth = 1
+        self.layer.shadowRadius = 0
+        self.layer.shadowOpacity = 1
+    }
+
+    // 둥근 버튼 프로퍼티
+    private func configureCommonPropertiesForRounded() {
+        self.titleLabel?.font = UIFont.KoreanButtonText
+        self.layer.cornerRadius = 24
+    }
+
+    // 사각 버튼 프로퍼티
+    private func configureCommonPropertiesForSquare() {
+        self.titleLabel?.font = UIFont.KoreanButtonText
+        self.layer.cornerRadius = 8
+    }
+
+    // 하프 버튼 프로퍼티
+    private func configureCommonPropertiesForHalf() {
+        self.titleLabel?.font = UIFont.KoreanButtonText
+        self.layer.cornerRadius = 42
+    }
+
+    // 작은 버튼 프로퍼티
+    private func configureCommonPropertiesForSmall() {
+        self.titleLabel?.font = UIFont.KoreanSmallButtonText
+        self.layer.cornerRadius = 16
+    }
+
+    // 활성 상태 프로퍼티
+    private func configureActiveProperties() {
+        self.setTitleColor(.TextPrimary, for: .normal)
+        self.layer.borderColor = UIColor.BorderPrimary.cgColor
+        self.layer.shadowColor = UIColor.BorderPrimary.cgColor
+    }
+
+    // 비활성 상태 프로퍼티
+    private func configureDeactiveProperties() {
+        self.setTitleColor(.TextDeactivate, for: .normal)
+        self.layer.borderColor = UIColor.BorderDeactivate.cgColor
+        self.layer.shadowColor = UIColor.BorderDeactivate.cgColor
+    }
+
+    // 일반 버튼, 사용자가 탭하기 전 프로퍼티
+    private func configureUnpressedProperties() {
+        self.layer.shadowOffset = CGSize(width: 0, height: 8)
+    }
+
+    // 일반 버튼, 사용자가 탭한 뒤 프로퍼티
+    private func configurePressedProperties() {
+        self.isEnabled = false
+        self.layer.shadowOffset = CGSize(width: 0, height: 3)
+    }
+
+    // 사각 버튼, 사용자가 탭하기 전 프로퍼티
+    private func configureUnpressedPropertiesForSquare() {
+        self.layer.shadowOffset = CGSize(width: 0, height: 3)
+    }
+
+    // 사각 버튼, 사용자가 탭한 뒤 프로퍼티
+    private func configurePressedPropertiesForSquare() {
+        self.isEnabled = false
+        self.layer.shadowOffset = CGSize(width: 0, height: 1)
+    }
+    
+    // 하프 버튼 폰트 및 타입페이스 일괄 설정 프로퍼티
+    private func configureHalfButtonFontProperties() {
+        currencyLabel.font = UIFont.KoreanButtonText
+    }
+
+    private func configureHalfButtonStringSmartSplitProperties() {
+        currencyLabel.text = "쓴 만큼 정산하기"
+    }
+
+    private func configureHalfButtonStringEqualSplitProperties() {
+        currencyLabel.text = "1/n 정산하기"
+    }
+
+    private func configureHalfButtonStringShareProperties() {
+        currencyLabel.text = "친구와 공유하기"
+    }
+
+    private func configureHalfButtonStringExitProperties() {
+        currencyLabel.text = "스플리릿 끝내기"
+    }
+    
+    // applyStyle 
+    
+    func applyStyle(style: Style, shape: Shape) {
+        setCurrencyIcon(style: style)
+        setCurrencyLabel(style: style)
+
+        disposeBag = DisposeBag()
+
+        configureCommonProperties()
+
+        switch shape {
+        case .rounded:
+            self.configureCommonPropertiesForRounded()
+
+            buttonState
+                .asDriver(onErrorJustReturn: false)
+                .drive(onNext: { [weak self] isEnable in
+                guard let self = self else { return }
+                self.isEnabled = isEnable
+                configureCommonProperties()
+                if isEnable {
+                    self.backgroundColor = colorArray[style]
+                    self.configureActiveProperties()
+                    self.configureUnpressedProperties()
+                } else {
+                    self.backgroundColor = .AppColorBrandCalmshell
+                    self.configureDeactiveProperties()
+                    self.configurePressedProperties()
+                }
+            })
+                .disposed(by: disposeBag)
+
+            Observable.merge(self.rx.controlEvent(.touchUpInside).asObservable(),
+                self.rx.controlEvent(.touchUpOutside).asObservable())
+                .observe(on: MainScheduler.asyncInstance)
+                .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.backgroundColor = colorArray[style]
+                self.isEnabled = true
+                self.configureActiveProperties()
+                self.configureUnpressedProperties()
+            })
+                .disposed(by: disposeBag)
+
+            self.rx.controlEvent(.touchDown)
+                .observe(on: MainScheduler.asyncInstance)
+                .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.configurePressedProperties()
+                self.backgroundColor = colorPressedArray[style]
+            })
+                .disposed(by: disposeBag)
+
+        case .square:
+            self.configureCommonPropertiesForSquare()
+
+            buttonState
+                .asDriver(onErrorJustReturn: false)
+                .drive(onNext: { [weak self] isEnable in
+                guard let self = self else { return }
+                self.isEnabled = isEnable
+                if isEnable {
+                    self.backgroundColor = colorArray[style]
+                    self.configureActiveProperties()
+                    self.configureUnpressedPropertiesForSquare()
+                } else {
+                    self.backgroundColor = .AppColorBrandCalmshell
+                    self.configureDeactiveProperties()
+                    self.configurePressedPropertiesForSquare()
+                }
+            })
+                .disposed(by: disposeBag)
+
+            Observable.merge(self.rx.controlEvent(.touchUpInside).asObservable(),
+                self.rx.controlEvent(.touchUpOutside).asObservable())
+                .observe(on: MainScheduler.asyncInstance)
+                .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.isEnabled = true
+                self.configureActiveProperties()
+                self.configureUnpressedPropertiesForSquare()
+            })
+                .disposed(by: disposeBag)
+
+
+            self.rx.controlEvent(.touchDown)
+                .observe(on: MainScheduler.asyncInstance)
+                .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.configurePressedPropertiesForSquare()
+                self.backgroundColor = colorPressedArray[style]
+            })
+                .disposed(by: disposeBag)
+
+        case .half:
+            self.configureCommonPropertiesForHalf()
+
+            buttonState
+                .asDriver(onErrorJustReturn: false)
+                .drive(onNext: { [weak self] isEnable in
+                guard let self = self else { return }
+                self.isEnabled = isEnable
+                if isEnable {
+                    self.backgroundColor = colorArray[style]
+                    self.configureActiveProperties()
+                    self.configureUnpressedProperties()
+                } else {
+                    self.backgroundColor = .AppColorBrandCalmshell
+                    self.configureDeactiveProperties()
+                    self.configurePressedProperties()
+                }
+            })
+                .disposed(by: disposeBag)
+
+            Observable.merge(self.rx.controlEvent(.touchUpInside).asObservable(),
+                self.rx.controlEvent(.touchUpOutside).asObservable())
+                .observe(on: MainScheduler.asyncInstance)
+                .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.isEnabled = true
+                self.configureActiveProperties()
+                self.configureUnpressedProperties()
+            })
+                .disposed(by: disposeBag)
+
+
+            self.rx.controlEvent(.touchDown)
+                .observe(on: MainScheduler.asyncInstance)
+                .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.configurePressedProperties()
+                self.backgroundColor = colorPressedArray[style]
+            })
+                .disposed(by: disposeBag)
+        }
+
+        switch style {
+
+            // 활성 버튼, Unpressed 상태
+        case .primaryCalmshell:
+            print("primaryCalmshell")
+        case .primaryWatermelon:
+            print("primaryWatermelon")
+        case .primaryCherry:
+            print("primaryCherry")
+        case .primaryPear:
+            print("primaryPear")
+        case .primaryMushroom:
+            print("primaryMushroom")
+        case .primaryRadish:
+            print("primaryRadish")
+        case .warningRed:
+            print("warningRed")
+
+            // 활성 하프 버튼
+        case .halfSmartSplit:
+            print("halfSmartSplit")
+        case .halfEqualSplit:
+            print("halfEqualSplit")
+
+            // 작은 버튼
+        case .smallButton:
+            self.backgroundColor = .SurfaceSelected
+            self.configureCommonPropertiesForSmall()
+            self.configureActiveProperties()
+        }
+    }
+    
+    // 하프 버튼에 아이콘 추가
+    private func setCurrencyIcon(style: NewSPButton.Style) {
+        self.addSubview(currencyIcon)
+
+        currencyIcon.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(80)
+            $0.top.equalToSuperview().inset(14)
+        }
+
+        switch style {
+        case .primaryCalmshell:
+            break
+        case .primaryWatermelon:
+            break
+        case .primaryCherry:
+            break
+        case .primaryPear:
+            break
+        case .primaryMushroom:
+            break
+        case .primaryRadish:
+            break
+        case .warningRed:
+            break
+        case .smallButton:
+            break
+
+        case .halfSmartSplit:
+            currencyIcon.image = UIImage(named: "SmartSplitIconDefault")
+        case .halfEqualSplit:
+            currencyIcon.image = UIImage(named: "EqualSplitIconDefault")
+        }
+    }
+
+    // 하프 버튼에 라벨 추가
+    private func setCurrencyLabel(style: NewSPButton.Style) {
+        self.addSubview(currencyLabel)
+
+        currencyLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(25)
+        }
+
+        switch style {
+        case .primaryCalmshell:
+            break
+        case .primaryWatermelon:
+            break
+        case .primaryCherry:
+            break
+        case .primaryPear:
+            break
+        case .primaryMushroom:
+            break
+        case .primaryRadish:
+            break
+        case .warningRed:
+            break
+        case .smallButton:
+            break
+
+        case .halfSmartSplit:
+            self.configureHalfButtonStringSmartSplitProperties()
+            self.configureHalfButtonFontProperties()
+        case .halfEqualSplit:
+            self.configureHalfButtonStringEqualSplitProperties()
+            self.configureHalfButtonFontProperties()
+        }
+    }
+}
+
+
+extension NewSPButton {
+    enum Style {
+
+        // MARK: Active Normal Button Styles
+        case primaryCalmshell
+        case primaryWatermelon
+        case primaryCherry
+        case primaryPear
+        case primaryMushroom
+        case primaryRadish
+        case warningRed
+
+        // MARK: Active Half Button Styles
+        case halfSmartSplit
+        case halfEqualSplit
+
+        // MARK: Active Small Button Style
+        case smallButton
+    }
+
+    enum Shape {
+        case rounded
+        case square
+        case half
+    }
+}


### PR DESCRIPTION
### 작업 내용 설명
1. @hsw1920 과의 협업으로 `SPbutton.swift`를 복제한 `NewSPButton.swift`을 생성하여 리팩토링하였습니다.
2. 기존에 상태값과 관계 없이 병렬적으로 존재하던 모든 스타일 컴포넌트들을 하나 컴포넌트 안에 상태 값에 따라 변하게끔 설정하였습니다. 이에따라 Pressed와 Deactivate 컴포넌트들이 제거되었습니다.
4. `NewSPButton.swift`에서는 rx를 사용하게 되었습니다.
5. 위 과정들을 통해 버튼을 누름과 동시에 즉각적으로 반응하게끔 사용자 경험이 수정되었습니다.

### 관련 이슈
- #116 

### 작업의 비고사항
- 기존에는 SPButton의 두가지 컴포넌트 case를 switch 하였으나, 앞으로는 VC에서 buttonState의 Bool 값을 전달하면 됩니다.
ex) `self.버튼변수명.buttonState.accept(false)`

Close #116
