### PR TITLE
[Feat/#180] `UIDevice+.swift`를 생성하고, `UIFont+.swift`를 수정하였습니다

### DIFF
--- a/SplitIt.xcodeproj/project.pbxproj
+++ b/SplitIt.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		86C660002AF126DE00A7942A /* EditCSListVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C65FFF2AF126DE00A7942A /* EditCSListVM.swift */; };
 		86D1E0C52AE6B4C100FBF610 /* ExclEditPageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D1E0C42AE6B4C100FBF610 /* ExclEditPageController.swift */; };
 		C229F51A2AEA442E00F9E28D /* NewSPButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C229F5192AEA442E00F9E28D /* NewSPButton.swift */; };
+		C291BA132AF4DD6F009501F3 /* UIDevice+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C291BA122AF4DD6F009501F3 /* UIDevice+.swift */; };
 		C2A7978D2AE2740D0049E709 /* ONEMobileBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A7978A2AE2740D0049E709 /* ONEMobileBold.ttf */; };
 		C2A7978E2AE2740D0049E709 /* ONEMobileLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A7978B2AE2740D0049E709 /* ONEMobileLight.ttf */; };
 		C2A7978F2AE2740D0049E709 /* ONEMobileRegular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A7978C2AE2740D0049E709 /* ONEMobileRegular.ttf */; };
@@ -312,6 +313,7 @@
 		86C65FFF2AF126DE00A7942A /* EditCSListVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCSListVM.swift; sourceTree = "<group>"; };
 		86D1E0C42AE6B4C100FBF610 /* ExclEditPageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclEditPageController.swift; sourceTree = "<group>"; };
 		C229F5192AEA442E00F9E28D /* NewSPButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSPButton.swift; sourceTree = "<group>"; };
+		C291BA122AF4DD6F009501F3 /* UIDevice+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+.swift"; sourceTree = "<group>"; };
 		C2A7978A2AE2740D0049E709 /* ONEMobileBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ONEMobileBold.ttf; sourceTree = "<group>"; };
 		C2A7978B2AE2740D0049E709 /* ONEMobileLight.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ONEMobileLight.ttf; sourceTree = "<group>"; };
 		C2A7978C2AE2740D0049E709 /* ONEMobileRegular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ONEMobileRegular.ttf; sourceTree = "<group>"; };
@@ -569,6 +571,7 @@
 				C2A797902AE2748E0049E709 /* UIFont+.swift */,
 				1A07DF0A2AE569660081E543 /* UIButton+.swift */,
 				60AE3EBB2AE7743E009D9D18 /* UITableView+.swift */,
+				C291BA122AF4DD6F009501F3 /* UIDevice+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1532,6 +1535,7 @@
 				1A4DB2512ADEB24300616243 /* RealmMemberLog.swift in Sources */,
 				DE1711CC2AE0BAF90097850D /* PayData.swift in Sources */,
 				1A4DB22B2ADE68E400616243 /* SplitRepository.swift in Sources */,
+				C291BA132AF4DD6F009501F3 /* UIDevice+.swift in Sources */,
 				869D1ACE2AE5298B00D166B1 /* CSEditListCell.swift in Sources */,
 				1A3852FD2ADE5B0100E9A20B /* ExclMember.swift in Sources */,
 				DE73D6FC2AE1993F00ABF3EF /* MemberCell.swift in Sources */,

--- a/SplitIt/Resources/Extensions/UIDevice+.swift
+++ b/SplitIt/Resources/Extensions/UIDevice+.swift
@@ -1,0 +1,31 @@
+//
+//  UIDevice+.swift
+//  SplitIt
+//
+//  Created by SUNGIL-POS on 2023/11/03.
+//
+
+import UIKit
+
+public extension UIDevice {
+    
+    var iPhone: Bool {
+        return UIDevice().userInterfaceIdiom == .phone
+    }
+
+    enum ScreenType: String {
+        case iPhoneSE
+        case defaultDevice
+    }
+
+    var screenType: ScreenType {
+        guard iPhone else { return .defaultDevice }
+        switch UIScreen.main.nativeBounds.width {
+        case 750: // for iPhone SE Generation 3
+            return .iPhoneSE
+        default: // for Other Devices
+            return .defaultDevice
+        }
+    }
+    
+}

--- a/SplitIt/Resources/Extensions/UIFont+.swift
+++ b/SplitIt/Resources/Extensions/UIFont+.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIFont {
-    
+
     // MARK: Korean Typeface
 
     /**
@@ -16,46 +16,72 @@ extension UIFont {
      - parameters:
         - property: $korean-title1
      */
+
     class var KoreanTitle1: UIFont {
-        return UIFont(name: "ONEMobileRegular", size: 30)!
+        switch UIDevice().screenType {
+        case .iPhoneSE:
+            return UIFont(name: "ONEMobileRegular", size: 28)!
+        case .defaultDevice:
+            return UIFont(name: "ONEMobileRegular", size: 30)!
+        }
     }
-    
+
     /**
      27pt / Korean / Title 2
      - parameters:
         - property: $korean-title2
      */
     class var KoreanTitle2: UIFont {
-        return UIFont(name: "ONEMobileRegular", size: 27)!
+        switch UIDevice().screenType {
+        case .iPhoneSE:
+            return UIFont(name: "ONEMobileRegular", size: 25)!
+        case .defaultDevice:
+            return UIFont(name: "ONEMobileRegular", size: 27)!
+        }
     }
-    
+
     /**
      24pt / Korean / Title 3
      - parameters:
         - property: $korean-title3
      */
     class var KoreanTitle3: UIFont {
-        return UIFont(name: "ONEMobileRegular", size: 24)!
+        switch UIDevice().screenType {
+        case .iPhoneSE:
+            return UIFont(name: "ONEMobileRegular", size: 22)!
+        case .defaultDevice:
+            return UIFont(name: "ONEMobileRegular", size: 24)!
+        }
     }
-    
+
     /**
      21pt / Korean / Subtitle
      - parameters:
         - property: $korean-subtitle
      */
     class var KoreanSubtitle: UIFont {
-        return UIFont(name: "ONEMobileRegular", size: 21)!
+        switch UIDevice().screenType {
+        case .iPhoneSE:
+            return UIFont(name: "ONEMobileRegular", size: 19)!
+        case .defaultDevice:
+            return UIFont(name: "ONEMobileRegular", size: 21)!
+        }
     }
-    
+
     /**
      18pt / Korean / Body
      - parameters:
         - property: $korean-body
      */
     class var KoreanBody: UIFont {
-        return UIFont(name: "ONEMobileRegular", size: 18)!
+        switch UIDevice().screenType {
+        case .iPhoneSE:
+            return UIFont(name: "ONEMobileRegular", size: 16)!
+        case .defaultDevice:
+            return UIFont(name: "ONEMobileRegular", size: 18)!
+        }
     }
-    
+
     /**
      16pt / Korean / ButtonText
      - parameters:
@@ -64,7 +90,7 @@ extension UIFont {
     class var KoreanButtonText: UIFont {
         return UIFont(name: "ONEMobileBold", size: 16)!
     }
-    
+
     /**
      12pt / Korean / SmallButtonText
      - parameters:
@@ -73,16 +99,21 @@ extension UIFont {
     class var KoreanSmallButtonText: UIFont {
         return UIFont(name: "ONEMobileBold", size: 12)!
     }
-    
+
     /**
      15pt / Korean / Caption 1
      - parameters:
         - property: $korean-caption1
      */
     class var KoreanCaption1: UIFont {
-        return UIFont(name: "ONEMobileRegular", size: 15)!
+        switch UIDevice().screenType {
+        case .iPhoneSE:
+            return UIFont(name: "ONEMobileRegular", size: 14)!
+        case .defaultDevice:
+            return UIFont(name: "ONEMobileRegular", size: 15)!
+        }
     }
-    
+
     /**
      12pt / Korean / Caption 2
      - parameters:


### PR DESCRIPTION
### 작업 내용 설명
1. `UIDevice`를 이용하여 Device의 사이즈를 체크하여 그에 따라 case를 부여하였습니다.
2. 이를 바탕으로 `UIFont`단 에서 자동적으로 기기별 대응을 할 수 있게 작업하였습니다
3. 또한 `UIDevice`의 case를 사용하시면, 예를 들어 이미지와 같은 다른 것에 대해서도 각 VC단에서 기기별 대응이 가능할 수 있겠습니다.

### 관련 이슈
- #180 

### 작업의 결과물
#### `UIDevice+.swift`
```swift
public extension UIDevice {
    
    var iPhone: Bool {
        return UIDevice().userInterfaceIdiom == .phone
    }

    enum ScreenType: String {
        case iPhoneSE
        case defaultDevice
    }

    var screenType: ScreenType {
        guard iPhone else { return .defaultDevice }
        switch UIScreen.main.nativeBounds.width {
        case 750: // for iPhone SE Generation 3
            return .iPhoneSE
        default: // for Other Devices
            return .defaultDevice
        }
    }
    
}
```

#### `UIFont.swift`
```swift

...

    class var KoreanTitle1: UIFont {
        switch UIDevice().screenType {
        case .iPhoneSE:
            return UIFont(name: "ONEMobileRegular", size: 28)!
        case .defaultDevice:
            return UIFont(name: "ONEMobileRegular", size: 30)!
        }
    }

...

```


### 작업의 비고사항 및 한계점
- Caption2와 ButtonText는 크게 부자연스러운 부분은 없었어서 적용하지 않았습니다.

Close #180 
