### PR TITLE
[Fix/#212] SplitShareView 수정하였습니다.

### DIFF
--- a/SplitIt/Presenter/History/View/Cell/HistorySplitCell.swift
+++ b/SplitIt/Presenter/History/View/Cell/HistorySplitCell.swift
@@ -145,7 +145,7 @@ class HistorySplitCell: UICollectionViewCell, Reusable {
     }
     
     func configure(split: Split, index: Int) {
-        self.splitTitleLabel.text = split.title
+        self.splitTitleLabel.text = split.title == "" ? viewModel.getCSTitles(splitIdx: split.splitIdx) : split.title
         self.csTitleLabel.text = viewModel.getCSTitles(splitIdx: split.splitIdx)
         self.csMemberLabel.text = viewModel.getCSMembers()
         self.totalAmountLabel.text = viewModel.getTotalAmount()

--- a/SplitIt/Presenter/History/ViewModel/HistoryVM.swift
+++ b/SplitIt/Presenter/History/ViewModel/HistoryVM.swift
@@ -32,6 +32,7 @@ class HistoryVM {
             .drive(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 self.repo.fetchSplitArrFromDBForHistoryView()
+                self.repo.isCreate = false
             })
             .disposed(by: disposeBag)
         

--- a/SplitIt/Presenter/SplitCreateFlow/CSInfo/ViewModel/CSInfoVM.swift
+++ b/SplitIt/Presenter/SplitCreateFlow/CSInfo/ViewModel/CSInfoVM.swift
@@ -75,6 +75,8 @@ class CSInfoVM {
             .drive(onNext: { title, totalAmount in
                 SplitRepository.share.inputCSInfoWithTitle(title: title)
                 SplitRepository.share.inputCSInfoWithTotalAmount(totalAmount: totalAmount)
+                
+                SplitRepository.share.isCreate = true
             })
             .disposed(by: disposeBag)
         

--- a/SplitIt/Presenter/SplitShare/View/SplitShareVC.swift
+++ b/SplitIt/Presenter/SplitShare/View/SplitShareVC.swift
@@ -65,7 +65,6 @@ class SplitShareVC: UIViewController {
         
         csAddButton.do {
             $0.applyStyle(style: .primaryMushroom, shape: .square)
-            $0.setTitle("+ 2차 추가", for: .normal)
             $0.buttonState.accept(true)
         }
         
@@ -148,6 +147,7 @@ class SplitShareVC: UIViewController {
             .drive(onNext: { [weak self] csInfos in
                 guard let self = self else { return }
                 self.csInfos = csInfos
+                csAddButton.setTitle("+ \(csInfos.count+1)차 추가", for: .normal)
             })
             .disposed(by: disposeBag)
         
@@ -155,7 +155,7 @@ class SplitShareVC: UIViewController {
             .asDriver()
             .drive(onNext: { [weak self] in
                 guard let self = self else { return }
-                self.splitDate = $0.map { $0.createDate }.first!
+                self.splitDate = $0.map { $0.createDate }.first ?? .now
             })
             .disposed(by: disposeBag)
         

--- a/SplitIt/Repository/SplitRepository.swift
+++ b/SplitIt/Repository/SplitRepository.swift
@@ -28,6 +28,7 @@ final class SplitRepository {
     private init() { }
     
     var isSmartSplit = true
+    var isCreate = true
 }
 
 extension SplitRepository {
@@ -356,24 +357,9 @@ extension SplitRepository {
     /// csInfoIdx를 기준으로 csInfo 삭제 및 연관 데이터 전체 삭제
     func deleteCSInfoAndRelatedData(csInfoIdx: String) {
         let realmManager = RealmManager()
-        let csInfos: [CSInfo] = csInfoArr.value
-        var deleteCSInfo: CSInfo?
-        var newCSInfos: [CSInfo] = []
+        let deleteCSInfo: [CSInfo] = csInfoArr.value
         
-        for info in csInfos {
-            if info.csInfoIdx == csInfoIdx {
-                deleteCSInfo = info
-            } else {
-                newCSInfos.append(info)
-            }
-        }
-        
-        csInfoArr.accept(newCSInfos)
-        realmManager.deleteCSInfo(csInfoIdxArr: [deleteCSInfo!.csInfoIdx])
-        
-        if newCSInfos.isEmpty {
-            deleteSplitAndRelatedData(splitIdx: deleteCSInfo!.splitIdx)
-        }
+        realmManager.deleteCSInfo(csInfoIdxArr: [deleteCSInfo.first!.csInfoIdx])
     }
     
     /// csMemberIdx를 기준으로 csMember 삭제 및 연관 데이터 전체 삭제

--- a/SplitIt/Resources/Components/SPNavigationBar.swift
+++ b/SplitIt/Resources/Components/SPNavigationBar.swift
@@ -105,8 +105,13 @@ final class SPNavigationBar: UIView {
             setLeftBackButton(action: .toBack, vc: vc)
             setRightBackButton(title: "확인", titleColor: .SurfaceBrandWatermelon, vc: vc)
         case .print:
-            setNaviTitle(title: "정산 영수증")
-            setExitButton(vc: vc)
+            if SplitRepository.share.isCreate {
+                setNaviTitle(title: "정산 결과")
+                setExitButton(vc: vc)
+            } else {
+                setNaviTitle(title: "정산 결과")
+                setLeftBackButton(action: .toBack, vc: vc)
+            }
         case .history:
             setNaviTitle(title: "과거 정산 내역")
             setLeftBackButton(action: .toBack, vc: vc)


### PR DESCRIPTION
### 작업 내용 설명
1. 이제 SplitShareView의 차수 추가 버튼이 현재 차수에 비례하여 변화합니다.
2. SplitShareView의 NavigationBar의 버튼이 상태에 따라 backButton과 ExitButton으로 변화합니다.
3. HistoryView의 Title부분이 Split의 Title 값 여부에 따라 변화합니다.

### 관련 이슈
- #212 

### 작업의 비고사항 및 한계점
- 현재는 Coordinate와 같이 Flow에 따른 구별을 View가 알 수 있는 방법이 없어 임시로 SplitRepository를 활용하였습니다.
- 해당 부분은 추후 논의를 통해 필수로 고쳤으면 합니다.

Close #212 
