### PR TITLE
[Feat/#241] SplitRepository에 csInfo가 생성될 때 title의 기본값(1차, 2차 등)을 자동으로 설정하는 기능을 추가하였습니다.

### DIFF
--- a/SplitIt/Models/LocalModels/CSInfo.swift
+++ b/SplitIt/Models/LocalModels/CSInfo.swift
@@ -14,9 +14,9 @@ struct CSInfo {
     var totalAmount: Int
     var splitIdx: String
     
-    init(splitIdx: String) {
+    init(splitIdx: String, title: String) {
         self.csInfoIdx = ObjectId.generate().stringValue
-        self.title = ""
+        self.title = title
         self.totalAmount = 0
         self.splitIdx = splitIdx
     }

--- a/SplitIt/Presenter/SplitCreateFlow/CSInfo/View/CSInfoVC.swift
+++ b/SplitIt/Presenter/SplitCreateFlow/CSInfo/View/CSInfoVC.swift
@@ -189,7 +189,10 @@ class CSInfoVC: UIViewController, SPAlertDelegate {
                                    exitButtonTapped: header.rightButton.rx.tap,
                                    backButtonTapped: header.leftButton.rx.tap
         )
+        
         let output = viewModel.transform(input: input)
+        
+        titleTextFiled.text = output.titleInitialValue
         
         output.showCSMemberView
             .drive(onNext: { [weak self] _ in

--- a/SplitIt/Presenter/SplitCreateFlow/CSInfo/ViewModel/CSInfoVM.swift
+++ b/SplitIt/Presenter/SplitCreateFlow/CSInfo/ViewModel/CSInfoVM.swift
@@ -26,6 +26,7 @@ class CSInfoVM {
     }
     
     struct Output {
+        let titleInitialValue: String
         let showCSMemberView: Driver<Void>
         let titleCount: Driver<String>
         let totalAmount: Driver<String>
@@ -39,6 +40,8 @@ class CSInfoVM {
     }
     
     func transform(input: Input) -> Output {
+        let titleInitialValue = SplitRepository.share.csInfoArr.value.first!.title
+        
         let title = input.title
         let showCSTotalAmountView = input.nextButtonTapped
         let textFieldCount = BehaviorRelay<String>(value: "")
@@ -123,7 +126,8 @@ class CSInfoVM {
             .drive(totalAmountIsValid)
             .disposed(by: disposeBag)
         
-        return Output(showCSMemberView: showCSTotalAmountView.asDriver(),
+        return Output(titleInitialValue: titleInitialValue,
+                      showCSMemberView: showCSTotalAmountView.asDriver(),
                       titleCount: textFieldCount.asDriver(),
                       totalAmount: totalAmountString,
                       titleTextFieldIsValid: titleTextFieldIsValid,

--- a/SplitIt/Repository/SplitRepository.swift
+++ b/SplitIt/Repository/SplitRepository.swift
@@ -93,7 +93,7 @@ extension SplitRepository {
     /// 새로운 split, csInfo, csMember(default: 나) 생성 => MainView에서 split it 버튼 클릭시 호출되도록 설정
     func createDatasForCreateFlow() {
         let newSplit = Split()
-        let newCSInfo = CSInfo(splitIdx: newSplit.splitIdx)
+        let newCSInfo = CSInfo(splitIdx: newSplit.splitIdx, title: "1차")
         let name = UserDefaults.standard.string(forKey: "userNickName") == "" ? "정산자" : UserDefaults.standard.string(forKey: "userNickName") ?? "정산자"
         let newCSMember = CSMember(csInfoIdx: newCSInfo.csInfoIdx, name: name)
         
@@ -147,10 +147,12 @@ extension SplitRepository {
     
     /// 현재 splitIdx를 기준으로 CSInfo부터 아래 데이터들만 새로 생성
     func createNewCS() {
+        let currentCSInfoCount = getCurrentSplitCSInfoCount()
+        
         let splitIdx = splitArr.value.first!.splitIdx
         let preCSInfo = csInfoArr.value.last!.csInfoIdx
         let preCSMember = csMemberArr.value.filter { $0.csInfoIdx == preCSInfo }
-        let newCSInfo = CSInfo(splitIdx: splitIdx)
+        let newCSInfo = CSInfo(splitIdx: splitIdx, title: "\(currentCSInfoCount + 1)차")
         var newCSMembers: [CSMember] = []
         
         preCSMember.forEach {
@@ -181,6 +183,12 @@ extension SplitRepository {
         }
         
         exclMemberArr.accept(exclMembers)
+    }
+    
+    private func getCurrentSplitCSInfoCount() -> Int {
+        return RealmManager()
+            .bringCSInfoWithSplitIdxArr(splitIdxArr: [splitArr.value.first!.splitIdx])
+            .count
     }
 }
 


### PR DESCRIPTION
SplitRepository에 csInfo가 생성될 때 title의 기본값(1차, 2차 등)을 자동으로 설정하는 기능을 추가하였습니다.

### 작업 내용 설명
1. SplitRepository에 csInfo가 생성될 때 title의 기본값(1차, 2차 등)을 자동으로 설정하는 기능 추가
2. CSInfoVC에서 title의 TextField가 새로 생성된 csInfo의 title을 구독하도록 설정

### 관련 이슈
- #241 

Close #241 
