### PR TITLE
[Design/#329] SPButton의 홈화면 버튼의 디자인을 수정하고 SurfaceSecondary의 색상 스타일 추가하였습니다.

### DIFF
--- a/SplitIt/Resources/Components/SPButton.swift
+++ b/SplitIt/Resources/Components/SPButton.swift
@@ -192,9 +192,9 @@ extension SPButton {
         case primaryPear
         case primaryMushroom
         case primaryRadish
-        case warningRed
         case surfaceWhite
         case surfaceSecondary
+        case warningRed
     }
     
     enum Shape {

--- a/SplitIt/Resources/Components/SPButton.swift
+++ b/SplitIt/Resources/Components/SPButton.swift
@@ -23,8 +23,9 @@ final class SPButton: UIButton {
         .primaryPear: .SurfaceBrandPear,
         .primaryMushroom: .SurfaceBrandMushroom,
         .primaryRadish: .SurfaceBrandRadish,
-        .warningRed: .SurfaceWarnRed,
-        .surfaceWhite: .SurfaceWhite
+        .surfaceWhite: .SurfaceWhite,
+        .surfaceSecondary: .SurfaceSecondary,
+        .warningRed: .SurfaceWarnRed
     ]
     
     let colorPressedArray: [Style: UIColor] = [
@@ -34,8 +35,9 @@ final class SPButton: UIButton {
         .primaryPear: .SurfaceBrandPearPressed,
         .primaryMushroom: .SurfaceBrandMushroomPressed,
         .primaryRadish: .SurfaceBrandRadishPressed,
-        .warningRed: .SurfaceWarnRedPressed,
-        .surfaceWhite: .SurfaceSelected
+        .surfaceWhite: .SurfaceSelected,
+        .surfaceSecondary: .SurfaceSecondaryPressed,
+        .warningRed: .SurfaceWarnRedPressed
     ]
 
     func applyStyle(style: Style, shape: Shape) {
@@ -192,6 +194,7 @@ extension SPButton {
         case primaryRadish
         case warningRed
         case surfaceWhite
+        case surfaceSecondary
     }
     
     enum Shape {
@@ -226,6 +229,7 @@ extension SPButton {
     // Home 관련 버튼 프로퍼티
     private func configureCommonPropertiesForHome() {
         self.layer.cornerRadius = 8
+        self.layer.borderWidth = 2
     }
     
     // 활성 상태 프로퍼티


### PR DESCRIPTION
### 작업 내용 설명
1. SPButton의 홈화면 버튼의 border 스타일을 figma 디자인에 맞게 수정
2. SPButton에 SurfaceSecondary의 색상 스타일 추가

### 관련 이슈
- #329 

### 작업의 결과물
```swift

...

let colorArray: [Style: UIColor] = [
  ...
  .surfaceSecondary: .SurfaceSecondary,
  ...
]

let colorPressedArray: [Style: UIColor] = [
  ...
  .surfaceSecondary: .SurfaceSecondaryPressed,
  ...
]

...

extension SPButton {
  enum Style {
    ...
    case surfaceSecondary
    ...
}
...

// Home 관련 버튼 프로퍼티
private func configureCommonPropertiesForHome() {
  ...
  self.layer.borderWidth = 2
}

...

```

### To Reviewers
- @jincode93 

Close #329 